### PR TITLE
Assign Timeout.tv_sec only once in CheckForSSLData

### DIFF
--- a/havp/sockethandler.cpp
+++ b/havp/sockethandler.cpp
@@ -581,7 +581,7 @@ int SocketHandler::CheckForSSLData( int sockBrowser, int sockServer )
         fds = sockServer;
     }
 
-    Timeout.tv_sec = Timeout.tv_sec = Params::GetConfigInt("SSLTIMEOUT");
+    Timeout.tv_sec = Params::GetConfigInt("SSLTIMEOUT");
     Timeout.tv_usec = 0;
 
     int ret = select_eintr(fds+1, &readfd, NULL, NULL, &Timeout);


### PR DESCRIPTION
Fixes compiler warning about possible undefined behavior/value -
missing sequence point.

```
sockethandler.cpp: In member function 'int
    SocketHandler::CheckForSSLData(int, int)':
sockethandler.cpp:590:20: warning: operation on
    '((SocketHandler*)this)->SocketHandler::Timeout.timeval::tv_sec' may be
    undefined [-Wsequence-point]
590 |     Timeout.tv_sec = Timeout.tv_sec = Params::GetConfigInt("SSLTIMEOUT");
    |     ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```